### PR TITLE
Feature datadir

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,8 +4,13 @@
  * @desc general configuration options for the server
  */
 
-module.exports = {
-	httpPort: 8080,
-	dbPort:   27017,
-	dbName:   'paper_hub_dev'
-}
+var config = {};
+
+config.httpPort = 8080;
+config.dbPort   = 27017;
+config.dbName   = 'paper_hub_dev';
+config.dataDir  = { path: __dirname + '/data' };    // the directory where publications will be stored
+config.dataDir.widgets = config.dataDir.path + '/widgets';
+config.dataDir.papers  = config.dataDir.path + '/papers';
+
+module.exports = config;

--- a/index.js
+++ b/index.js
@@ -5,7 +5,9 @@
  */
 
 var config  = require('./config.js');
+var util    = require('./util.js');
 var mongo   = require('./dbConnector.js');
+var async = require('async');
 var express = require('express');
 
 var app          = express();
@@ -29,5 +31,16 @@ mongo.connect(
 	}
 );
 
-/* serve everything in the folder './public/' */
-app.use(express.static(__dirname + '/public'));
+/* check if the datadir exists & create it if necessary */
+util.createPath([config.dataDir.papers, config.dataDir.widgets], function(err) {
+	if (err) {
+		console.error('couldnt find nor create data directory: ' + err);
+		process.exit(2);
+	}
+});
+
+/* serve the static pages of the site under '/' */
+app.use('/', express.static(__dirname + '/public'));
+
+/* serve the data directory under '/data', to make the converted HTML and widgets available */
+app.use('/data', express.static(config.dataDir.path));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "webplatform to submit and read interactive scientific articles",
   "main": "index.js",
   "dependencies": {
+    "async": "^1.5.0",
     "express": "^4.13.3",
+    "mkdirp": "^0.5.1",
     "mongoose": "^4.2.7",
     "passport": "^0.3.2"
   },

--- a/util.js
+++ b/util.js
@@ -1,0 +1,35 @@
+"use strict";
+
+var mkdirp = require('mkdirp');
+var async  = require('async');
+
+/**
+ * @desc various utility functions needed by the server
+ */
+
+/**
+ * @desc  checks if a path exists, and creates it if not
+ * @param path:     String or Array of Strings of path(s) to create
+ * @param callback: node style callback
+ */
+exports.createPath = function(path, callback) {
+	if (path instanceof Array)
+		async.map(path, mkdirp, callback);
+	else
+		mkdirp(path, callback);
+};
+
+/**
+ * @desc  creates the necessary paths for a new paper
+ * @param parentPath: String path to parent of the new paper (eg. /data/papers/)
+ * @param UID:        String of the new paper
+ * @param callback:   node style callback
+ */
+exports.newPaperDir = function(parentPath, UID, callback) {
+	var paths = [
+		parentPath + '/' + UID + '/tex',
+		parentPath + '/' + UID + '/html',
+		parentPath + '/' + UID + '/datasets'
+	];
+	exports.createPath(paths, callback);
+}


### PR DESCRIPTION
Hey, hab den Pfad zum dataDir (wo nachher die widgets + papers liegen) in die `config.js` geschrieben.
So kann der potentielle Nutzer den Pfad einfach anpassen.
Zugriff erfolgt über `config.dataDir.widgets` oder `config.dataDir.papers`.

Zusätzlich hab ich 2 Funktionen zu `util.js` hinzugefügt:
- `util.createPath(path, callback)` nimmt einen Pfad oder ein Array von Pfaden entgegen, und prüft ob es Sie bereits gibt. Falls nicht werden die erstellt.
- `util.newPaperDir(parentDir, UID, callback)` erzeugt die nötigen Ordner für ein neues Paper.

Dazu hab ich die Bibliothek [`async`](https://www.npmjs.com/package/async) eingebunden, welche das Arbeiten mit asynchronen Dingen wie DB- und Dateisystem-Abfragen deutlich vereinfacht.
